### PR TITLE
ゲームの再試行機能の追加

### DIFF
--- a/src/components/CountryQuiz.js
+++ b/src/components/CountryQuiz.js
@@ -25,14 +25,12 @@ const CountryQuiz = () => {
     fetchCountryData();
   }, []);
 
-  const correctNumber = getRandomInt(4);
-
   return (
     <div className="quiz-field">
       {countryData === null ? (
         <div className="load">Loading...</div>
       ) : (
-        <Quiz countryDatas={countryData} correctNumber={correctNumber} />
+        <Quiz countryDatas={countryData} />
       )}
     </div>
   );

--- a/src/components/CountryQuiz.js
+++ b/src/components/CountryQuiz.js
@@ -25,22 +25,6 @@ const CountryQuiz = () => {
     fetchCountryData();
   }, []);
 
-  const chooseCountry = () => {
-    if (!countryData) {
-      return null;
-    }
-
-    let chooseData = new Set();
-    const countryDataLength = countryData.length;
-
-    while (chooseData.size < 4) {
-      chooseData.add(countryData[getRandomInt(countryDataLength)]);
-    }
-
-    return [...chooseData];
-  };
-
-  const choseCountry = chooseCountry();
   const correctNumber = getRandomInt(4);
 
   return (
@@ -48,7 +32,7 @@ const CountryQuiz = () => {
       {countryData === null ? (
         <div className="load">Loading...</div>
       ) : (
-        <Quiz countryDatas={choseCountry} correctNumber={correctNumber} />
+        <Quiz correctNumber={correctNumber} />
       )}
     </div>
   );

--- a/src/components/CountryQuiz.js
+++ b/src/components/CountryQuiz.js
@@ -32,7 +32,7 @@ const CountryQuiz = () => {
       {countryData === null ? (
         <div className="load">Loading...</div>
       ) : (
-        <Quiz correctNumber={correctNumber} />
+        <Quiz countryDatas={countryData} correctNumber={correctNumber} />
       )}
     </div>
   );

--- a/src/components/CountryQuiz.js
+++ b/src/components/CountryQuiz.js
@@ -6,6 +6,21 @@ export const getRandomInt = (max) => {
   return Math.floor(Math.random() * max);
 };
 
+export const chooseCountry = (countryData) => {
+  if (!countryData) {
+    return null;
+  }
+
+  let chooseData = new Set();
+  const countryDataLength = countryData.length;
+
+  while (chooseData.size < 4) {
+    chooseData.add(countryData[getRandomInt(countryDataLength)]);
+  }
+
+  return [...chooseData];
+};
+
 const CountryQuiz = () => {
   const [countryData, setCountryData] = useState(null);
 

--- a/src/components/CountryQuiz.js
+++ b/src/components/CountryQuiz.js
@@ -8,7 +8,6 @@ export const getRandomInt = (max) => {
 
 const CountryQuiz = () => {
   const [countryData, setCountryData] = useState(null);
-  const [scoreCount, setScoreCount] = useState(0);
 
   useEffect(() => {
     const fetchCountryData = async () => {
@@ -49,12 +48,7 @@ const CountryQuiz = () => {
       {countryData === null ? (
         <div className="load">Loading...</div>
       ) : (
-        <Quiz
-          countryDatas={choseCountry}
-          correctNumber={correctNumber}
-          scoreCount={scoreCount}
-          setScoreCount={setScoreCount}
-        />
+        <Quiz countryDatas={choseCountry} correctNumber={correctNumber} />
       )}
     </div>
   );

--- a/src/components/IsAnswered.js
+++ b/src/components/IsAnswered.js
@@ -1,0 +1,5 @@
+const IsAnswered = ({ answerIndex, children }) => {
+  return answerIndex === null ? null : <div>{children}</div>;
+};
+
+export default IsAnswered;

--- a/src/components/IsAnswered.js
+++ b/src/components/IsAnswered.js
@@ -1,5 +1,0 @@
-const IsAnswered = ({ answerIndex, children }) => {
-  return answerIndex === null ? null : <div>{children}</div>;
-};
-
-export default IsAnswered;

--- a/src/components/Quiz.js
+++ b/src/components/Quiz.js
@@ -42,7 +42,11 @@ const Quiz = ({ countryDatas, correctNumber, scoreCount, setScoreCount }) => {
   };
 
   return showResult ? (
-    <Result scoreCount={scoreCount} />
+    <Result
+      scoreCount={scoreCount}
+      setScoreCount={setScoreCount}
+      setShowResult={setShowResult}
+    />
   ) : (
     <div>
       {QUIZ_LIST[questionType]({ countryDatas, correctNumber })}

--- a/src/components/Quiz.js
+++ b/src/components/Quiz.js
@@ -54,6 +54,9 @@ const Quiz = ({ countryDatas }) => {
       scoreCount={scoreCount}
       setScoreCount={setScoreCount}
       setShowResult={setShowResult}
+      setChoseCountry={setChoseCountry}
+      countryDatas={countryDatas}
+      setCorrectNumber={setCorrectNumber}
     />
   ) : (
     <div>

--- a/src/components/Quiz.js
+++ b/src/components/Quiz.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import AnswerList from "./AnswerList";
 import { chooseCountry, getRandomInt } from "./CountryQuiz";
+import IsAnswered from "./IsAnswered";
 import Result from "./Result";
 
 const QUIZ_LIST = {
@@ -66,9 +67,11 @@ const Quiz = ({ countryDatas }) => {
           answerIndex={answerIndex}
         />
       </ol>
-      <button className="btn-next" onClick={() => onClick()}>
-        NEXT
-      </button>
+      <IsAnswered answerIndex={answerIndex}>
+        <button className="btn-next" onClick={() => onClick()}>
+          NEXT
+        </button>
+      </IsAnswered>
     </div>
   );
 };

--- a/src/components/Quiz.js
+++ b/src/components/Quiz.js
@@ -30,8 +30,6 @@ const Quiz = ({ countryDatas }) => {
   const [choseCountry, setChoseCountry] = useState(chooseCountry(countryDatas));
   const [correctNumber, setCorrectNumber] = useState(getRandomInt(4));
 
-  useEffect(() => {}, [choseCountry]);
-
   const onClick = () => {
     setAnswerIndex(null);
 

--- a/src/components/Quiz.js
+++ b/src/components/Quiz.js
@@ -43,9 +43,6 @@ const Quiz = ({ countryDatas }) => {
       setCorrectNumber(getRandomInt(4));
     } else {
       setShowResult(true);
-      if (scoreCount === 0) {
-        setScoreCount(-1);
-      }
     }
   };
 

--- a/src/components/Quiz.js
+++ b/src/components/Quiz.js
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import AnswerList from "./AnswerList";
 import { chooseCountry, getRandomInt } from "./CountryQuiz";
-import IsAnswered from "./IsAnswered";
 import Result from "./Result";
 
 const QUIZ_LIST = {
@@ -67,11 +66,11 @@ const Quiz = ({ countryDatas }) => {
           answerIndex={answerIndex}
         />
       </ol>
-      <IsAnswered answerIndex={answerIndex}>
-        <button className="btn-next" onClick={() => onClick()}>
+      {answerIndex !== null && (
+        <button className="btn-next" onClick={onClick}>
           NEXT
         </button>
-      </IsAnswered>
+      )}
     </div>
   );
 };

--- a/src/components/Quiz.js
+++ b/src/components/Quiz.js
@@ -20,12 +20,13 @@ const QUIZ_LIST = {
 const QUIZ_NAME = Object.keys(QUIZ_LIST);
 const QUIZ_LENGTH = QUIZ_NAME.length;
 
-const Quiz = ({ countryDatas, correctNumber, scoreCount, setScoreCount }) => {
+const Quiz = ({ countryDatas, correctNumber }) => {
   const [answerIndex, setAnswerIndex] = useState(null);
   const [questionType, setQuestionType] = useState(
     QUIZ_NAME[getRandomInt(QUIZ_LENGTH)]
   );
   const [showResult, setShowResult] = useState(false);
+  const [scoreCount, setScoreCount] = useState(0);
 
   useEffect(() => {
     setQuestionType(QUIZ_NAME[getRandomInt(QUIZ_LENGTH)]);

--- a/src/components/Quiz.js
+++ b/src/components/Quiz.js
@@ -30,9 +30,7 @@ const Quiz = ({ countryDatas }) => {
   const [choseCountry, setChoseCountry] = useState(chooseCountry(countryDatas));
   const [correctNumber, setCorrectNumber] = useState(getRandomInt(4));
 
-  useEffect(() => {
-    setQuestionType(QUIZ_NAME[getRandomInt(QUIZ_LENGTH)]);
-  }, [scoreCount]);
+  useEffect(() => {}, [choseCountry]);
 
   const onClick = () => {
     setAnswerIndex(null);
@@ -41,6 +39,7 @@ const Quiz = ({ countryDatas }) => {
       setScoreCount(scoreCount + 1);
       setChoseCountry(chooseCountry(countryDatas));
       setCorrectNumber(getRandomInt(4));
+      setQuestionType(QUIZ_NAME[getRandomInt(QUIZ_LENGTH)]);
     } else {
       setShowResult(true);
     }
@@ -51,6 +50,7 @@ const Quiz = ({ countryDatas }) => {
     setScoreCount(0);
     setChoseCountry(chooseCountry(countryDatas));
     setCorrectNumber(getRandomInt(4));
+    setQuestionType(QUIZ_NAME[getRandomInt(QUIZ_LENGTH)]);
   };
 
   return showResult ? (

--- a/src/components/Quiz.js
+++ b/src/components/Quiz.js
@@ -54,6 +54,8 @@ const Quiz = ({ countryDatas }) => {
 
     if (correctNumber === answerIndex) {
       setScoreCount(scoreCount + 1);
+      setChoseCountry(chooseCountry(countryDatas));
+      setCorrectNumber(getRandomInt(4));
     } else {
       setShowResult(true);
       if (scoreCount === 0) {

--- a/src/components/Quiz.js
+++ b/src/components/Quiz.js
@@ -19,15 +19,15 @@ const chooseCountry = (countryData) => {
 };
 
 const QUIZ_LIST = {
-  FlagBelongTo: ({ countryDatas, correctNumber }) => (
+  FlagBelongTo: ({ choseCountry, correctNumber }) => (
     <div>
-      <img src={countryDatas[correctNumber].flag} alt="flag" className="img" />
+      <img src={choseCountry[correctNumber].flag} alt="flag" className="img" />
       <h1 className="question">Which country does this flag belong to?</h1>
     </div>
   ),
-  CityIsCapitalOf: ({ countryDatas, correctNumber }) => (
+  CityIsCapitalOf: ({ choseCountry, correctNumber }) => (
     <h1 className="question">
-      {countryDatas[correctNumber].capital} is the capital of
+      {choseCountry[correctNumber].capital} is the capital of
     </h1>
   ),
 };
@@ -43,7 +43,7 @@ const Quiz = ({ countryDatas, correctNumber }) => {
   const [showResult, setShowResult] = useState(false);
   const [scoreCount, setScoreCount] = useState(0);
   const [choseCountry, setChoseCountry] = useState(chooseCountry(countryDatas));
-
+  console.log(choseCountry);
   useEffect(() => {
     setQuestionType(QUIZ_NAME[getRandomInt(QUIZ_LENGTH)]);
   }, [scoreCount]);
@@ -69,10 +69,10 @@ const Quiz = ({ countryDatas, correctNumber }) => {
     />
   ) : (
     <div>
-      {QUIZ_LIST[questionType]({ countryDatas, correctNumber })}
+      {QUIZ_LIST[questionType]({ choseCountry, correctNumber })}
       <ol>
         <AnswerList
-          countryDatas={countryDatas}
+          countryDatas={choseCountry}
           correctNumber={correctNumber}
           setAnswerIndex={setAnswerIndex}
           answerIndex={answerIndex}

--- a/src/components/Quiz.js
+++ b/src/components/Quiz.js
@@ -46,15 +46,15 @@ const Quiz = ({ countryDatas }) => {
     }
   };
 
+  const initialize = () => {
+    setShowResult(false);
+    setScoreCount(0);
+    setChoseCountry(chooseCountry(countryDatas));
+    setCorrectNumber(getRandomInt(4));
+  };
+
   return showResult ? (
-    <Result
-      scoreCount={scoreCount}
-      setScoreCount={setScoreCount}
-      setShowResult={setShowResult}
-      setChoseCountry={setChoseCountry}
-      countryDatas={countryDatas}
-      setCorrectNumber={setCorrectNumber}
-    />
+    <Result scoreCount={scoreCount} initialize={initialize} />
   ) : (
     <div>
       {QUIZ_LIST[questionType]({ choseCountry, correctNumber })}

--- a/src/components/Quiz.js
+++ b/src/components/Quiz.js
@@ -38,6 +38,9 @@ const Quiz = ({ countryDatas, correctNumber, scoreCount, setScoreCount }) => {
       setScoreCount(scoreCount + 1);
     } else {
       setShowResult(true);
+      if (scoreCount === 0) {
+        setScoreCount(-1);
+      }
     }
   };
 

--- a/src/components/Quiz.js
+++ b/src/components/Quiz.js
@@ -35,7 +35,7 @@ const QUIZ_LIST = {
 const QUIZ_NAME = Object.keys(QUIZ_LIST);
 const QUIZ_LENGTH = QUIZ_NAME.length;
 
-const Quiz = ({ countryDatas, correctNumber }) => {
+const Quiz = ({ countryDatas }) => {
   const [answerIndex, setAnswerIndex] = useState(null);
   const [questionType, setQuestionType] = useState(
     QUIZ_NAME[getRandomInt(QUIZ_LENGTH)]
@@ -43,7 +43,8 @@ const Quiz = ({ countryDatas, correctNumber }) => {
   const [showResult, setShowResult] = useState(false);
   const [scoreCount, setScoreCount] = useState(0);
   const [choseCountry, setChoseCountry] = useState(chooseCountry(countryDatas));
-  console.log(choseCountry);
+  const [correctNumber, setCorrectNumber] = useState(getRandomInt(4));
+
   useEffect(() => {
     setQuestionType(QUIZ_NAME[getRandomInt(QUIZ_LENGTH)]);
   }, [scoreCount]);

--- a/src/components/Quiz.js
+++ b/src/components/Quiz.js
@@ -3,6 +3,21 @@ import AnswerList from "./AnswerList";
 import { getRandomInt } from "./CountryQuiz";
 import Result from "./Result";
 
+const chooseCountry = (countryData) => {
+  if (!countryData) {
+    return null;
+  }
+
+  let chooseData = new Set();
+  const countryDataLength = countryData.length;
+
+  while (chooseData.size < 4) {
+    chooseData.add(countryData[getRandomInt(countryDataLength)]);
+  }
+
+  return [...chooseData];
+};
+
 const QUIZ_LIST = {
   FlagBelongTo: ({ countryDatas, correctNumber }) => (
     <div>

--- a/src/components/Quiz.js
+++ b/src/components/Quiz.js
@@ -1,22 +1,7 @@
 import { useEffect, useState } from "react";
 import AnswerList from "./AnswerList";
-import { getRandomInt } from "./CountryQuiz";
+import { chooseCountry, getRandomInt } from "./CountryQuiz";
 import Result from "./Result";
-
-const chooseCountry = (countryData) => {
-  if (!countryData) {
-    return null;
-  }
-
-  let chooseData = new Set();
-  const countryDataLength = countryData.length;
-
-  while (chooseData.size < 4) {
-    chooseData.add(countryData[getRandomInt(countryDataLength)]);
-  }
-
-  return [...chooseData];
-};
 
 const QUIZ_LIST = {
   FlagBelongTo: ({ choseCountry, correctNumber }) => (

--- a/src/components/Quiz.js
+++ b/src/components/Quiz.js
@@ -42,6 +42,7 @@ const Quiz = ({ countryDatas, correctNumber }) => {
   );
   const [showResult, setShowResult] = useState(false);
   const [scoreCount, setScoreCount] = useState(0);
+  const [choseCountry, setChoseCountry] = useState(chooseCountry(countryDatas));
 
   useEffect(() => {
     setQuestionType(QUIZ_NAME[getRandomInt(QUIZ_LENGTH)]);

--- a/src/components/Result.js
+++ b/src/components/Result.js
@@ -1,25 +1,9 @@
-import { chooseCountry, getRandomInt } from "./CountryQuiz";
-
-const Result = ({
-  scoreCount,
-  setScoreCount,
-  setShowResult,
-  setChoseCountry,
-  countryDatas,
-  setCorrectNumber,
-}) => {
-  const onClick = () => {
-    setShowResult(false);
-    setScoreCount(0);
-    setChoseCountry(chooseCountry(countryDatas));
-    setCorrectNumber(getRandomInt(4));
-  };
-
+const Result = ({ scoreCount, initialize }) => {
   return (
     <div>
       <h2>Results</h2>
       <p>You got {scoreCount} correct answer</p>
-      <button onClick={() => onClick()}>Try again</button>
+      <button onClick={() => initialize()}>Try again</button>
     </div>
   );
 };

--- a/src/components/Result.js
+++ b/src/components/Result.js
@@ -18,7 +18,7 @@ const Result = ({
   return (
     <div>
       <h2>Results</h2>
-      <p>You got {scoreCount === -1 ? 0 : scoreCount} correct answer</p>
+      <p>You got {scoreCount} correct answer</p>
       <button onClick={() => onClick()}>Try again</button>
     </div>
   );

--- a/src/components/Result.js
+++ b/src/components/Result.js
@@ -1,7 +1,18 @@
-const Result = ({ scoreCount, setScoreCount, setShowResult }) => {
+import { chooseCountry, getRandomInt } from "./CountryQuiz";
+
+const Result = ({
+  scoreCount,
+  setScoreCount,
+  setShowResult,
+  setChoseCountry,
+  countryDatas,
+  setCorrectNumber,
+}) => {
   const onClick = () => {
     setShowResult(false);
     setScoreCount(0);
+    setChoseCountry(chooseCountry(countryDatas));
+    setCorrectNumber(getRandomInt(4));
   };
 
   return (

--- a/src/components/Result.js
+++ b/src/components/Result.js
@@ -1,8 +1,14 @@
-const Result = ({ scoreCount }) => {
+const Result = ({ scoreCount, setScoreCount, setShowResult }) => {
+  const onClick = () => {
+    setShowResult(false);
+    setScoreCount(0);
+  };
+
   return (
     <div>
       <h2>Results</h2>
       <p>You got {scoreCount} correct answer</p>
+      <button onClick={() => onClick()}>Try again</button>
     </div>
   );
 };

--- a/src/components/Result.js
+++ b/src/components/Result.js
@@ -7,7 +7,7 @@ const Result = ({ scoreCount, setScoreCount, setShowResult }) => {
   return (
     <div>
       <h2>Results</h2>
-      <p>You got {scoreCount} correct answer</p>
+      <p>You got {scoreCount === -1 ? 0 : scoreCount} correct answer</p>
       <button onClick={() => onClick()}>Try again</button>
     </div>
   );


### PR DESCRIPTION
## 追加内容　21/08/14　21:00　更新
1. `Quiz`コンポーネントの`button`の出現判定を`IsAnswered`コンポーネントから論理演算子を使用するように変更
2. 初期化用の`setState`を`initialize`関数にまとめて、`Result`コンポーネントに渡すように変更
3. `scoreCount`が0の時にリザルト表示して`try again`をクリックしても`questionType`が変わらない問題を修正
4. 消し忘れの`useEffect`を削除

## 追加内容　21/08/14

1. `scoreCount`ステートを`Quiz`コンポーネントへ移動
2. `chooseCountry`関数を`Quiz`コンポーネントへ移動
3. `countryData`を`Quiz`コンポーネントへ渡すように変更
4. `choseCountry`をステートに保存するように変更
5. `Quiz`コンポーネント内の`countryDatas`変数をステートの`choseCountry`で置き換え
6. `correctNumber`を`Quiz`コンポーネントのステートへ移動
7. 正解時のステート初期化処理に`setChoseCountry`と`setCorrectNumber`を追加
8. `chooseCountry`を`CountryQuiz`コンポーネントへ移動し、`export`するように変更
9. `Result`コンポーネント内のTry again`button`のステート初期化処理に`setChoseCountry`と`setCorrectNumber`を追加
10. 上記変更に伴い不要になった`Quiz`内の`if`と`Result`内の三項演算子を削除
11. `answerIndex`が`null`か否かで内容を表示するか判定する`IsAnswered`コンポーネントを追加
12. `IsAnswered`コンポーネントで`button`タグを囲むように変更

## 追加内容　21/08/13

1. 各ステートをリセットし、再試行する機能の追加
2. 正解数が`0`の時に`scoreCount`を`-1`に設定し、正解数が`0`の場合でもレンダリングが行われるように変更