### PR TITLE
Feature/layout quiz component

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -211,7 +211,6 @@ header {
 }
 
 .material-icons {
-  margin-left: 18px;
   font-size: 20px;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -33,18 +33,7 @@ header {
 }
 
 .question {
-  display: inline-block;
-  width: 373px;
-  height: 36px;
-  margin-right: 32px;
-  margin-left: 32px;
-
-  font-family: Poppins;
-  font-style: normal;
-  font-weight: bold;
-  font-size: 24px;
-  line-height: 36px;
-
+  line-height: 1.5;
   color: #2f527b;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -37,6 +37,12 @@ header {
   color: #2f527b;
 }
 
+.question > h1 {
+  font-size: 24px;
+  font-weight: 700;
+  margin: 0;
+}
+
 .question.questionCapitalOf {
   margin-top: 68px;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -111,11 +111,9 @@ header {
   color: white;
 }
 
-.img {
+.question > .img {
   width: 84px;
-  height: 54px;
-  margin-top: 68px;
-  margin-left: 32px;
+  vertical-align: middle;
 
   filter: drop-shadow(0px 4px 24px rgba(0, 0, 0, 0.1));
   border-radius: 4px;

--- a/src/App.css
+++ b/src/App.css
@@ -88,10 +88,11 @@ header {
 
 .btnNext {
   width: 116px;
-  height: 56px;
-  margin-top: 32px;
-  margin-right: 32px;
   margin-left: auto;
+  padding: 14px 0;
+  font-weight: 700;
+  font-size: 18px;
+  color: #fff;
 
   background: #f9a826;
   box-shadow: 0px 2px 4px rgba(252, 168, 47, 0.4);

--- a/src/App.css
+++ b/src/App.css
@@ -43,6 +43,10 @@ header {
   margin: 0;
 }
 
+.question > h1:not(:first-child) {
+  margin-top: 20px;
+}
+
 .question.questionCapitalOf {
   margin-top: 68px;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -66,6 +66,8 @@ header {
   align-items: center;
   margin: 0;
   padding: 0;
+  justify-content: center;
+  line-height: 1.5;
 }
 
 .btn:hover {

--- a/src/App.css
+++ b/src/App.css
@@ -203,7 +203,7 @@ header {
 }
 
 .dataName {
-  margin-left: 40px;
+  margin: 0 18px 0 40px;
   font-size: 18px;
   text-align: left;
   width: 100%;

--- a/src/App.css
+++ b/src/App.css
@@ -47,15 +47,6 @@ header {
   margin-top: 20px;
 }
 
-.question.questionCapitalOf {
-  margin-top: 68px;
-}
-
-.question.questionFlagBelongTo {
-  margin-top: 28px;
-  color: #1d355d;
-}
-
 .btn {
   display: flex;
   width: 120px;

--- a/src/App.css
+++ b/src/App.css
@@ -100,20 +100,6 @@ header {
   border-color: transparent;
 }
 
-.btnNext > span {
-  width: 43px;
-  height: 27px;
-  margin: auto;
-
-  font-family: Poppins;
-  font-style: normal;
-  font-weight: bold;
-  font-size: 18px;
-  line-height: 27px;
-
-  color: #ffffff;
-}
-
 .incorrect {
   background: #ea8282 !important;
   color: white;

--- a/src/App.css
+++ b/src/App.css
@@ -232,3 +232,7 @@ header {
 .quizWrapper {
   padding: 32px;
 }
+
+.quizContainer > div {
+  padding-top: 32px;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -228,3 +228,7 @@ header {
   margin-left: 18px;
   font-size: 20px;
 }
+
+.quizWrapper {
+  padding: 32px;
+}

--- a/src/components/Quiz.js
+++ b/src/components/Quiz.js
@@ -8,16 +8,12 @@ const QUIZ_LIST = {
   FlagBelongTo: ({ choseCountry, correctNumber }) => (
     <div className="question">
       <img src={choseCountry[correctNumber].flag} alt="flag" className="img" />
-      <h1 className="questionFlagBelongTo">
-        Which country does this flag belong to?
-      </h1>
+      <h1>Which country does this flag belong to?</h1>
     </div>
   ),
   CityIsCapitalOf: ({ choseCountry, correctNumber }) => (
     <div className="question">
-      <h1 className="questionCapitalOf">
-        {choseCountry[correctNumber].capital} is the capital of
-      </h1>
+      <h1>{choseCountry[correctNumber].capital} is the capital of</h1>
     </div>
   ),
 };

--- a/src/components/Quiz.js
+++ b/src/components/Quiz.js
@@ -14,9 +14,11 @@ const QUIZ_LIST = {
     </div>
   ),
   CityIsCapitalOf: ({ choseCountry, correctNumber }) => (
-    <h1 className="question questionCapitalOf">
-      {choseCountry[correctNumber].capital} is the capital of
-    </h1>
+    <div>
+      <h1 className="question questionCapitalOf">
+        {choseCountry[correctNumber].capital} is the capital of
+      </h1>
+    </div>
   ),
 };
 

--- a/src/components/Quiz.js
+++ b/src/components/Quiz.js
@@ -59,7 +59,7 @@ const Quiz = ({ countryDatas }) => {
       {showResult ? (
         <Result scoreCount={scoreCount} initialize={initialize} />
       ) : (
-        <div>
+        <div className="quizContainer">
           <img className="advIcon" src={AdventureIcon} alt="Icon" />
 
           {QUIZ_LIST[questionType]({ choseCountry, correctNumber })}

--- a/src/components/Quiz.js
+++ b/src/components/Quiz.js
@@ -64,8 +64,8 @@ const Quiz = ({ countryDatas }) => {
         <div className="quizContainer">
           <img className="advIcon" src={AdventureIcon} alt="Icon" />
 
+          <div>{QUIZ_LIST[questionType]({ choseCountry, correctNumber })}</div>
           <div>
-            {QUIZ_LIST[questionType]({ choseCountry, correctNumber })}
             <ol className="answerList">
               <AnswerList
                 countryDatas={choseCountry}
@@ -74,6 +74,8 @@ const Quiz = ({ countryDatas }) => {
                 answerIndex={answerIndex}
               />
             </ol>
+          </div>
+          <div>
             {answerIndex !== null && (
               <button className="btn btnNext" onClick={onClick}>
                 Next

--- a/src/components/Quiz.js
+++ b/src/components/Quiz.js
@@ -54,25 +54,29 @@ const Quiz = ({ countryDatas }) => {
     setQuestionType(QUIZ_NAME[getRandomInt(QUIZ_LENGTH)]);
   };
 
-  return showResult ? (
-    <Result scoreCount={scoreCount} initialize={initialize} />
-  ) : (
-    <div>
-      <img className="advIcon" src={AdventureIcon} alt="Icon" />
+  return (
+    <div className="quizWrapper">
+      {showResult ? (
+        <Result scoreCount={scoreCount} initialize={initialize} />
+      ) : (
+        <div>
+          <img className="advIcon" src={AdventureIcon} alt="Icon" />
 
-      {QUIZ_LIST[questionType]({ choseCountry, correctNumber })}
-      <ol className="answerList">
-        <AnswerList
-          countryDatas={choseCountry}
-          correctNumber={correctNumber}
-          setAnswerIndex={setAnswerIndex}
-          answerIndex={answerIndex}
-        />
-      </ol>
-      {answerIndex !== null && (
-        <button className="btn btnNext" onClick={onClick}>
-          <span>Next</span>
-        </button>
+          {QUIZ_LIST[questionType]({ choseCountry, correctNumber })}
+          <ol className="answerList">
+            <AnswerList
+              countryDatas={choseCountry}
+              correctNumber={correctNumber}
+              setAnswerIndex={setAnswerIndex}
+              answerIndex={answerIndex}
+            />
+          </ol>
+          {answerIndex !== null && (
+            <button className="btn btnNext" onClick={onClick}>
+              <span>Next</span>
+            </button>
+          )}
+        </div>
       )}
     </div>
   );

--- a/src/components/Quiz.js
+++ b/src/components/Quiz.js
@@ -76,7 +76,7 @@ const Quiz = ({ countryDatas }) => {
             </ol>
             {answerIndex !== null && (
               <button className="btn btnNext" onClick={onClick}>
-                <span>Next</span>
+                Next
               </button>
             )}
           </div>

--- a/src/components/Quiz.js
+++ b/src/components/Quiz.js
@@ -62,20 +62,22 @@ const Quiz = ({ countryDatas }) => {
         <div className="quizContainer">
           <img className="advIcon" src={AdventureIcon} alt="Icon" />
 
-          {QUIZ_LIST[questionType]({ choseCountry, correctNumber })}
-          <ol className="answerList">
-            <AnswerList
-              countryDatas={choseCountry}
-              correctNumber={correctNumber}
-              setAnswerIndex={setAnswerIndex}
-              answerIndex={answerIndex}
-            />
-          </ol>
-          {answerIndex !== null && (
-            <button className="btn btnNext" onClick={onClick}>
-              <span>Next</span>
-            </button>
-          )}
+          <div>
+            {QUIZ_LIST[questionType]({ choseCountry, correctNumber })}
+            <ol className="answerList">
+              <AnswerList
+                countryDatas={choseCountry}
+                correctNumber={correctNumber}
+                setAnswerIndex={setAnswerIndex}
+                answerIndex={answerIndex}
+              />
+            </ol>
+            {answerIndex !== null && (
+              <button className="btn btnNext" onClick={onClick}>
+                <span>Next</span>
+              </button>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/src/components/Quiz.js
+++ b/src/components/Quiz.js
@@ -6,16 +6,16 @@ import AdventureIcon from "../image/undraw_adventure_4hum 1.svg";
 
 const QUIZ_LIST = {
   FlagBelongTo: ({ choseCountry, correctNumber }) => (
-    <div>
+    <div className="question">
       <img src={choseCountry[correctNumber].flag} alt="flag" className="img" />
-      <h1 className="question questionFlagBelongTo">
+      <h1 className="questionFlagBelongTo">
         Which country does this flag belong to?
       </h1>
     </div>
   ),
   CityIsCapitalOf: ({ choseCountry, correctNumber }) => (
-    <div>
-      <h1 className="question questionCapitalOf">
+    <div className="question">
+      <h1 className="questionCapitalOf">
         {choseCountry[correctNumber].capital} is the capital of
       </h1>
     </div>


### PR DESCRIPTION
## 追加内容　21/08/24 18:30

1. １つの`div`で3要素を囲んでいたものを個別の`div`でそれぞれ囲むように変更
2. 不要になったCSSクラスを削除

## 追加内容　21/08/24

1. 三項演算子全体を`div`でラップし、CSSクラス`quizWrapper`を追加
2. CSSに`quizWrapper`セレクタを追加し、スタイルを設定
3. 三項演算子内の`div`にCSSクラス`quizContainer`を追加
4. `quizContainer`内の`img`を除く要素を`div`で囲むように変更
5. CSSに`.quizContainer > div`セレクタを追加し、スタイルを設定（`quizContainer`に追加した`div`のセレクタにスタイルを追加）
6. `QUIZ_LIST`の`CityIsCapitalOf`の`h1`を`div`でラップするように変更
7. `h1`の`question`クラスを親要素の`div`タグに移動
8. `question`CSSクラスのスタイルを修正
9. `.img`CSSクラスを`.question > .img`へ変更し、スタイルを修正
10. CSSに`.question > .h1`を追加し、スタイルを設定
11. CSSに`.question > h1:not(:first-child)`を追加し、スタイルを設定
12. `.btn`にスタイルを追加
13. `.btnNext`のスタイルを修正
14. `.btnNext > span`を削除
15. `14`の変更に伴い、不要になった`span`タグを削除
16. `.dataName`の`margin`を修正
17. `.material-icons`の`margin-left`を削除